### PR TITLE
Problems with latest ReactJS

### DIFF
--- a/alerts.jsx
+++ b/alerts.jsx
@@ -1,5 +1,5 @@
-var React = require("react/addons");
-var ReactCSSTransitionGroup = React.addons.CSSTransitionGroup;
+var React = require("react");
+var ReactCSSTransitionGroup = require("react-addons-css-transition-group");
 require("./styles.less");
 
 var AlertsNotifier = React.createClass({

--- a/alerts.jsx
+++ b/alerts.jsx
@@ -1,5 +1,5 @@
-var React = require("react");
-var ReactCSSTransitionGroup = require("react-addons-css-transition-group");
+var React = require("react/addons");
+var ReactCSSTransitionGroup = React.addons.CSSTransitionGroup;
 require("./styles.less");
 
 var AlertsNotifier = React.createClass({

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bootstrap",
     "alerts"
   ],
-  "main": "alerts.js",
+  "main": "alerts.jsx",
   "author": "Chad Lee <npm@chadly.net>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     ]
   },
   "dependencies": {
-    "node-lessify": "0.0.10",
-    "react": "^0.13.2"
+    "node-lessify": "0.0.10"
   },
   "devDependencies": {
+    "react": "^0.13.2",
     "jshint": "^2.7.0",
     "react-tools": "^0.13.2",
     "reactify": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -34,8 +34,11 @@
   "dependencies": {
     "node-lessify": "0.0.10"
   },
+  "peerDependencies": {
+    "react": "^0.14.2",
+    "react-addons-css-transition-group": "^0.14.2"
+  },
   "devDependencies": {
-    "react": "^0.13.2",
     "jshint": "^2.7.0",
     "react-tools": "^0.13.2",
     "reactify": "^1.1.0"


### PR DESCRIPTION
Hi there,

I've been loving your notifier, but when I upgraded to the latest version of reactjs today I kept getting some really strange errors about how the AlertsNotifier wasn't a valid react component.  Doing some research online, it looked like because react was included in the package.json under dependencies instead of peer or dev dependencies, it was pulling its own version of react and then causing the error to happen.

Another issue was that it said that the require('react/addons') was deprecated and to pull the react-addons-{addon} instead.

Since I'm never a fan of people who just complain about bugs and do nothing about it, I've changed the code to use the new require and changed the react library to be a dev dependency and created this pull request.  Let me know if you have any problems with formatting, or if you think there is a better solution.

Thanks for all the hard work!
