### PR TITLE
Add transition timeouts

### DIFF
--- a/alerts.jsx
+++ b/alerts.jsx
@@ -34,7 +34,7 @@ var AlertsNotifier = React.createClass({
 		i = -1;
 		return (
 			<div className="alert-notifier-container">
-				<ReactCSSTransitionGroup transitionName="alert">
+				<ReactCSSTransitionGroup transitionName="alert" transitionEnterTimeout={500} transitionLeaveTimeout={300}>
 					{alerts.map(function (item) {
 						i++;
 


### PR DESCRIPTION
This avoids a React warning in React 0.14:

"Warning: Failed propType: transitionEnterTimeout wasn't supplied to ReactCSSTransitionGroup: this can cause unreliable animations and won't be supported in a future version of React. See https://fb.me/react-animation-transition-group-timeout for more information."
