### PR TITLE
Upgrade to react-jss 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bs-notifier",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "A react component to show growl-like notifications using bootstrap alerts",
   "keywords": [
     "react-component",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "react-addons-css-transition-group": ">=0.14 <16",
-    "react-jss-preset-civicsource": "1.x",
+    "react-jss": "5.x",
     "toetag": "3.x"
   },
   "peerDependencies": {

--- a/src/alert.jsx
+++ b/src/alert.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import { bootstrap } from "toetag";
 import Icon from "./icon";
 
-import useSheet from "react-jss-preset-civicsource";
+import useSheet from "react-jss";
 
 const styles = {
 	innerAlert: {
@@ -57,4 +57,4 @@ const Alert = ({
 	);
 };
 
-export default useSheet(Alert, styles);
+export default useSheet(styles)(Alert);

--- a/src/container.jsx
+++ b/src/container.jsx
@@ -2,7 +2,7 @@ import React, { PropTypes as t } from "react";
 import ReactCSSTransitionGroup from "react-addons-css-transition-group";
 
 import { bootstrap } from "toetag";
-import useSheet from "react-jss-preset-civicsource";
+import useSheet from "react-jss";
 
 const MAGICAL_MAX_HEIGHT = "20em";
 export const ENTER_TIMEOUT = 500;
@@ -77,4 +77,4 @@ export const PropTypes = {
 
 AlertContainer.propTypes = PropTypes;
 
-export default useSheet(AlertContainer, styles);
+export default useSheet(styles)(AlertContainer);


### PR DESCRIPTION
jss-preset-default is now included with react-jss and has parity with the plugins which were specified in react-jss-preset-civicsource.