### PR TITLE
Use jss-compose, allow custom themes

### DIFF
--- a/docs/demos/code-example.jsx
+++ b/docs/demos/code-example.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import Playground from "component-playground";
 import { Alert, AlertList, AlertContainer } from "../../src";
+import useSheet from "react-jss";
 import Markdown from "react-remarkable";
 
 import "./code.css";
@@ -9,7 +10,7 @@ import "./code.css";
 const CodeExample = ({ title, description, ...props }) => (
 	<div>
 		<h3>{title}</h3>
-		<Playground scope={{ React, ReactDOM, Alert, AlertList, AlertContainer }} noRender={false} theme="solarized dark" collapsableCode initiallyExpanded={false} {...props} />
+		<Playground scope={{ React, ReactDOM, Alert, AlertList, AlertContainer, useSheet }} noRender={false} theme="solarized dark" collapsableCode initiallyExpanded={false} {...props} />
 		<Markdown source={description} />
 	</div>
 );

--- a/docs/demos/index.jsx
+++ b/docs/demos/index.jsx
@@ -3,6 +3,7 @@ import React from "react";
 import AlertListDemo from "./alert-list";
 import AlertDemo from "./alert";
 import AlertContainerDemo from "./alert-container";
+import ThemedAlertDemo from "./themed";
 
 const Demos = () => (
 	<div>
@@ -15,6 +16,9 @@ const Demos = () => (
 		<hr />
 
 		<AlertContainerDemo />
+		<hr />
+
+		<ThemedAlertDemo />
 		<hr />
 	</div>
 );

--- a/docs/demos/themed/code.example
+++ b/docs/demos/themed/code.example
@@ -47,11 +47,7 @@ const styles = {
 	}
 };
 
-const ThemableAlert = props => (
-    <Alert {...props} />
-);
-
-const ThemedAlert = useSheet(styles)(ThemableAlert);
+const ThemedAlert = useSheet(styles)(Alert);
 
 const themedExample = (
     <ThemedAlert type="success" headline="What have I done">

--- a/docs/demos/themed/code.example
+++ b/docs/demos/themed/code.example
@@ -1,0 +1,62 @@
+const { Component } = React;
+
+const styles = {
+	alert: {
+		composes: "alert",
+		marginBottom: 6,
+		display: "inline-block",
+		textAlign: "left"
+	},
+	info: {
+		composes: "alert-info"
+	},
+	success: {
+        color: "#efd8f0",
+        background: "#8f2ba1",
+        borderColor: "#80237f",
+        borderWidth: 15,
+        borderRadius: 60
+	},
+	warning: {
+		composes: "alert-warning",
+	},
+	danger: {
+		composes: "alert-danger"
+	},
+	dismissable: {
+		composes: "alert-dismissable"
+	},
+	close: {
+		composes: "close"
+	},
+	msgContainer: {
+		display: "inline-block"
+	},
+	icon: {
+		verticalAlign: "top",
+		fontSize: 18,
+		paddingRight: 15,
+		opacity: 0.2
+	},
+	headline: {
+		margin: 0,
+		marginBottom: 6
+	},
+	body: {
+		maxWidth: "40em"
+	}
+};
+
+const ThemableAlert = props => (
+    <Alert {...props} />
+);
+
+const ThemedAlert = useSheet(styles)(ThemableAlert);
+
+const themedExample = (
+    <ThemedAlert type="success" headline="What have I done">
+        This terrible power should have never been unleashed
+    </ThemedAlert>
+);
+
+ReactDOM.render(themedExample, mountNode);

--- a/docs/demos/themed/description.md
+++ b/docs/demos/themed/description.md
@@ -1,0 +1,11 @@
+To customize the theme of an `Alert`, wrap it in a [react-jss](https://github.com/cssinjs/react-jss) higher-order component
+or provide it with a `sheet` prop shaped like the one react-jss provides:
+```
+{
+    classes: {
+        [className]: String
+    }
+}
+```
+
+Use [jss-compose](https://github.com/cssinjs/jss-compose) to include (or not include) any bootstrap classes (see example and source).

--- a/docs/demos/themed/index.jsx
+++ b/docs/demos/themed/index.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+import CodeExample from "../code-example";
+
+import ex from "raw!./code.example";
+import desc from "raw!./description.md";
+
+const ThemedAlertDemo = props => <CodeExample title={<span>Themed <code>Alert</code></span>} codeText={ex} description={desc} {...props} noRender={false} />;
+
+export default ThemedAlertDemo;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bs-notifier",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "A react component to show growl-like notifications using bootstrap alerts",
   "keywords": [
     "react-component",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "react-addons-css-transition-group": ">=0.14 <16",
-    "react-jss": "5.x",
+    "react-jss": ">= 5.2 <6",
     "toetag": "3.x"
   },
   "peerDependencies": {

--- a/src/alert.jsx
+++ b/src/alert.jsx
@@ -6,7 +6,6 @@ import useSheet from "react-jss";
 import styles from "./alert.style";
 
 const Alert = ({
-	containerComponent: Container = "div",
 	type = "info",
 	children,
 	headline,
@@ -20,7 +19,7 @@ const Alert = ({
 	const dismiss = isDismissable ? <button type="button" className={classes.close} title={dismissTitle} onClick={onDismiss}>&times;</button> : null;
 
 	return (
-		<Container> {/* this classless container is used by the transition group above... don't delete it */}
+		<div> {/* this classless container div is used by the transition group above... don't delete it */}
 			<div className={css}>
 				{dismiss}
 
@@ -30,7 +29,7 @@ const Alert = ({
 					<div className={classes.body}>{children}</div>
 				</div>
 			</div>
-		</Container>
+		</div>
 	);
 };
 

--- a/src/alert.jsx
+++ b/src/alert.jsx
@@ -1,52 +1,9 @@
 import React from "react";
 
-import { bootstrap } from "toetag";
 import Icon from "./icon";
 
 import useSheet from "react-jss";
-
-const styles = {
-	alert: {
-		composes: "alert",
-		marginBottom: bootstrap.paddingBaseVertical,
-		display: "inline-block",
-		textAlign: "left"
-	},
-	info: {
-		composes: "alert-info"
-	},
-	success: {
-		composes: "alert-success"
-	},
-	warning: {
-		composes: "alert-warning",
-	},
-	danger: {
-		composes: "alert-danger"
-	},
-	dismissable: {
-		composes: "alert-dismissable"
-	},
-	close: {
-		composes: "close"
-	},
-	msgContainer: {
-		display: "inline-block"
-	},
-	icon: {
-		verticalAlign: "top",
-		fontSize: bootstrap.fontSizeH4,
-		paddingRight: bootstrap.paddingLargeHorizontal,
-		opacity: 0.2
-	},
-	headline: {
-		margin: 0,
-		marginBottom: bootstrap.paddingBaseVertical
-	},
-	body: {
-		maxWidth: "40em"
-	}
-};
+import styles from "./alert.style";
 
 const Alert = ({
 	containerComponent: Container = "div",

--- a/src/alert.jsx
+++ b/src/alert.jsx
@@ -6,10 +6,29 @@ import Icon from "./icon";
 import useSheet from "react-jss";
 
 const styles = {
-	innerAlert: {
+	alert: {
+		composes: "alert",
 		marginBottom: bootstrap.paddingBaseVertical,
 		display: "inline-block",
 		textAlign: "left"
+	},
+	info: {
+		composes: "alert-info"
+	},
+	success: {
+		composes: "alert-success"
+	},
+	warning: {
+		composes: "alert-warning",
+	},
+	danger: {
+		composes: "alert-danger"
+	},
+	dismissable: {
+		composes: "alert-dismissable"
+	},
+	close: {
+		composes: "close"
 	},
 	msgContainer: {
 		display: "inline-block"
@@ -30,6 +49,7 @@ const styles = {
 };
 
 const Alert = ({
+	containerComponent: Container = "div",
 	type = "info",
 	children,
 	headline,
@@ -39,11 +59,11 @@ const Alert = ({
 	showIcon = true
 }) => {
 	const isDismissable = !!onDismiss;
-	const css = `alert ${isDismissable ? "alert-dismissible" : ""} alert-${type} ${classes.innerAlert}`;
-	const dismiss = isDismissable ? <button type="button" className="close" title={dismissTitle} onClick={onDismiss}>&times;</button> : null;
+	const css = `${isDismissable ? classes.dismissable : ""} ${classes[type]} ${classes.alert}`;
+	const dismiss = isDismissable ? <button type="button" className={classes.close} title={dismissTitle} onClick={onDismiss}>&times;</button> : null;
 
 	return (
-		<div> {/* this outer div is important so the alerts stack on top of one another... don't delete it */}
+		<Container> {/* this classless container is used by the transition group above... don't delete it */}
 			<div className={css}>
 				{dismiss}
 
@@ -53,7 +73,7 @@ const Alert = ({
 					<div className={classes.body}>{children}</div>
 				</div>
 			</div>
-		</div>
+		</Container>
 	);
 };
 

--- a/src/alert.style.js
+++ b/src/alert.style.js
@@ -1,0 +1,44 @@
+import { bootstrap } from "toetag";
+
+export default {
+	alert: {
+		composes: "alert",
+		marginBottom: bootstrap.paddingBaseVertical,
+		display: "inline-block",
+		textAlign: "left"
+	},
+	info: {
+		composes: "alert-info"
+	},
+	success: {
+		composes: "alert-success"
+	},
+	warning: {
+		composes: "alert-warning",
+	},
+	danger: {
+		composes: "alert-danger"
+	},
+	dismissable: {
+		composes: "alert-dismissable"
+	},
+	close: {
+		composes: "close"
+	},
+	msgContainer: {
+		display: "inline-block"
+	},
+	icon: {
+		verticalAlign: "top",
+		fontSize: bootstrap.fontSizeH4,
+		paddingRight: bootstrap.paddingLargeHorizontal,
+		opacity: 0.2
+	},
+	headline: {
+		margin: 0,
+		marginBottom: bootstrap.paddingBaseVertical
+	},
+	body: {
+		maxWidth: "40em"
+	}
+};


### PR DESCRIPTION
Since cssinjs/react-jss#47 landed it's now a cinch to override themes of child components.
Bumped dependency, ported bootstrap class references in `Alert` to use [jss-compose](https://github.com/cssinjs/jss-compose) and updated docs/demos with an example of a classy purple alert.

![themed alert docs screenshot](https://cloud.githubusercontent.com/assets/1239439/22029163/4baba4dc-dc9f-11e6-8c1d-0ac0e68bfcbd.png)
