### PR TITLE
Upgrade to work with React 16

### DIFF
--- a/docs/demos/themed/description.md
+++ b/docs/demos/themed/description.md
@@ -1,10 +1,8 @@
 To customize the theme of an `Alert`, wrap it in a [react-jss](https://github.com/cssinjs/react-jss) higher-order component
-or provide it with a `sheet` prop shaped like the one react-jss provides:
+or provide it with a `classes` prop shaped like the one react-jss provides:
 ```
 {
-    classes: {
-        [className]: String
-    }
+    [className]: String
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "toetag": "3.x"
   },
   "peerDependencies": {
-    "react": "16.x"
+    "react": ">=15 <17"
   },
   "devDependencies": {
     "babel-cli": "6.x",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "compile-es": "rimraf es && babel src -d es --copy-files",
     "compile": "npm run compile-cjs && npm run compile-es",
     "build": "webpack --progress --bail",
-    "lint": "eslint src docs --ext=js,jsx",
-    "prepublish": "npm run lint && npm run compile"
+    "lint": "eslint src docs --ext=js,jsx"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "babel-plugin-transform-export-extensions": "6.x",
     "babel-preset-es2015": "6.x",
     "babel-preset-react": "6.x",
-    "babel-preset-react-hmre": "1.x",
     "babel-preset-stage-2": "6.x",
     "component-playground": "3.x",
     "cross-env": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bs-notifier",
-  "version": "5.0.0",
+  "version": "0.0.0",
   "description": "A react component to show growl-like notifications using bootstrap alerts",
   "keywords": [
     "react-component",
@@ -55,6 +55,7 @@
     "eslint": "3.x",
     "eslint-config-civicsource": "6.x",
     "json-loader": "0.5.x",
+    "json-update": "^3.0.0",
     "raw-loader": "0.5.x",
     "react": "16.x",
     "react-dom": "16.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bs-notifier",
-  "version": "4.3.2",
+  "version": "5.0.0",
   "description": "A react component to show growl-like notifications using bootstrap alerts",
   "keywords": [
     "react-component",
@@ -33,13 +33,13 @@
     "url": "https://github.com/chadly/react-bs-notifier/issues"
   },
   "dependencies": {
-    "prop-types": "^15.5.8",
-    "react-addons-css-transition-group": ">=0.14 <16",
+    "prop-types": "15.x",
     "react-jss": ">= 5.2 <8",
+    "react-transition-group": "2.x",
     "toetag": "3.x"
   },
   "peerDependencies": {
-    "react": ">=0.14 <16"
+    "react": "16.x"
   },
   "devDependencies": {
     "babel-cli": "6.x",
@@ -49,16 +49,16 @@
     "babel-preset-react": "6.x",
     "babel-preset-react-hmre": "1.x",
     "babel-preset-stage-2": "6.x",
-    "component-playground": "1.x",
+    "component-playground": "3.x",
     "cross-env": "^4.0.0",
     "css-loader": "0.25.x",
     "eslint": "3.x",
     "eslint-config-civicsource": "6.x",
     "json-loader": "0.5.x",
     "raw-loader": "0.5.x",
-    "react": "15.x",
-    "react-dom": "15.x",
-    "react-remarkable": "1.x",
+    "react": "16.x",
+    "react-dom": "16.x",
+    "react-remarkable": ">=1.1.2",
     "rimraf": "2.x",
     "style-loader": "0.13.x",
     "webpack": "2.x",

--- a/src/alert-list.jsx
+++ b/src/alert-list.jsx
@@ -1,8 +1,17 @@
 import React from "react";
 import { TransitionGroup } from "react-transition-group";
-
-import Container from "./container";
-import Alert from "./alert-timer";
+import {
+	any,
+	arrayOf,
+	func,
+	node,
+	object,
+	oneOfType,
+	shape,
+	string
+} from "prop-types";
+import Container, { PropTypes as ContainerPropTypes } from "./container";
+import Alert, { PropTypes as AlertPropTypes } from "./alert-timer";
 import AlertTransition from "./alert-transition";
 import styles from "./container/styles";
 
@@ -25,5 +34,21 @@ const AlertList = ({ position, alerts, onDismiss, ...props }) => (
 		</TransitionGroup>
 	</Container>
 );
+
+const { timeout, type, headline } = AlertPropTypes;
+
+AlertList.propTypes = {
+	...ContainerPropTypes,
+	alerts: arrayOf(
+		shape({
+			id: any.isRequired,
+			type,
+			headline,
+			message: oneOfType([string, node, object]).isRequired
+		})
+	).isRequired,
+	onDismiss: func,
+	timeout
+};
 
 export default styles(AlertList);

--- a/src/alert-list.jsx
+++ b/src/alert-list.jsx
@@ -1,37 +1,29 @@
 import React from "react";
-import * as t from "prop-types";
+import { TransitionGroup } from "react-transition-group";
 
-import Container, { PropTypes as ContainerPropTypes } from "./container";
-import Alert, { PropTypes as AlertPropTypes } from "./alert-timer";
+import Container from "./container";
+import Alert from "./alert-timer";
+import AlertTransition from "./alert-transition";
+import styles from "./container/styles";
 
 const AlertList = ({ position, alerts, onDismiss, ...props }) => (
 	<Container position={position}>
-		{alerts.map(item => {
-			const dismiss = onDismiss ? () => onDismiss(item) : null;
+		<TransitionGroup>
+			{alerts.map(item => {
+				const dismiss = onDismiss ? () => onDismiss(item) : null;
 
-			const { message, ...alertProps } = item;
+				const { message, ...alertProps } = item;
 
-			return (
-				<Alert key={item.id} {...props} {...alertProps} onDismiss={dismiss}>
-					{message}
-				</Alert>
-			);
-		})}
+				return (
+					<AlertTransition key={item.id}>
+						<Alert {...props} {...alertProps} onDismiss={dismiss}>
+							{message}
+						</Alert>
+					</AlertTransition>
+				);
+			})}
+		</TransitionGroup>
 	</Container>
 );
 
-AlertList.propTypes = {
-	...ContainerPropTypes,
-	alerts: t.arrayOf(
-		t.shape({
-			id: t.any.isRequired,
-			type: AlertPropTypes.type,
-			headline: AlertPropTypes.headline,
-			message: t.oneOfType([t.string, t.node, t.object]).isRequired
-		})
-	).isRequired,
-	onDismiss: t.func,
-	timeout: AlertPropTypes.timeout
-};
-
-export default AlertList;
+export default styles(AlertList);

--- a/src/alert-timer.jsx
+++ b/src/alert-timer.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import * as t from "prop-types";
 
 import Alert from "./alert";
 
@@ -66,14 +65,3 @@ export default class AlertTimer extends Component {
 		return <Alert {...this.props} onDismiss={onDismiss} />;
 	}
 }
-
-export const PropTypes = {
-	type: t.oneOf(["info", "success", "warning", "danger"]),
-	headline: t.string,
-	onDismiss: t.func,
-	dismissTitle: t.string,
-	showIcon: t.bool,
-	timeout: t.number
-};
-
-AlertTimer.propTypes = PropTypes;

--- a/src/alert-timer.jsx
+++ b/src/alert-timer.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { oneOf, string, func, bool, number } from "prop-types";
 
 import Alert from "./alert";
 
@@ -65,3 +66,14 @@ export default class AlertTimer extends Component {
 		return <Alert {...this.props} onDismiss={onDismiss} />;
 	}
 }
+
+export const PropTypes = {
+	type: oneOf(["info", "success", "warning", "danger"]),
+	headline: string,
+	onDismiss: func,
+	dismissTitle: string,
+	showIcon: bool,
+	timeout: number
+};
+
+AlertTimer.propTypes = PropTypes;

--- a/src/alert-transition.jsx
+++ b/src/alert-transition.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import transitionStyles from "./transition-styles";
+import { CSSTransition } from "react-transition-group";
+import { ENTER_TIMEOUT, EXIT_TIMEOUT } from "./container";
+import useSheet from "react-jss";
+
+const timeout = { enter: ENTER_TIMEOUT, exit: EXIT_TIMEOUT };
+
+const AlertTransition = ({ classes, ...props }) =>
+	props && props.children ? (
+		<CSSTransition timeout={timeout} classNames={classes} {...props} />
+	) : null;
+
+export default useSheet(transitionStyles)(AlertTransition);

--- a/src/alert/index.jsx
+++ b/src/alert/index.jsx
@@ -9,7 +9,7 @@ const Alert = ({
 	headline,
 	onDismiss,
 	dismissTitle = "Dismiss",
-	sheet: { classes },
+	classes,
 	showIcon = true
 }) => {
 	const isDismissable = !!onDismiss;
@@ -29,7 +29,6 @@ const Alert = ({
 
 	return (
 		<div>
-			{" "}
 			{/* this classless container div is used by the transition group above... don't delete it */}
 			<div className={css}>
 				{dismiss}

--- a/src/container/index.jsx
+++ b/src/container/index.jsx
@@ -1,34 +1,28 @@
-import React from "react";
-import * as t from "prop-types";
-import ReactCSSTransitionGroup from "react-addons-css-transition-group";
+import React, { Children, cloneElement } from "react";
+import { TransitionGroup } from "react-transition-group";
+import AlertTransition from "../alert-transition";
 
 import styles from "./styles";
 
 export const ENTER_TIMEOUT = 500;
 export const EXIT_TIMEOUT = 300;
 
-const AlertContainer = ({
-	position = "top-right",
-	children,
-	sheet: { classes }
-}) => {
+const AlertContainer = ({ position = "top-right", children, classes }) => {
 	return (
 		<div className={`${classes.container} ${classes[position]}`}>
-			<ReactCSSTransitionGroup
-				transitionName={classes}
-				transitionEnterTimeout={ENTER_TIMEOUT}
-				transitionLeaveTimeout={EXIT_TIMEOUT}
-			>
-				{children}
-			</ReactCSSTransitionGroup>
+			<TransitionGroup>
+				{Children.map(
+					children,
+					child =>
+						child ? (
+							<AlertTransition key={child.props.id}>
+								{cloneElement(child)}
+							</AlertTransition>
+						) : null
+				)}
+			</TransitionGroup>
 		</div>
 	);
 };
-
-export const PropTypes = {
-	position: t.oneOf(["top-right", "top-left", "bottom-right", "bottom-left"])
-};
-
-AlertContainer.propTypes = PropTypes;
 
 export default styles(AlertContainer);

--- a/src/container/index.jsx
+++ b/src/container/index.jsx
@@ -1,7 +1,7 @@
 import React, { Children, cloneElement } from "react";
+import { oneOf } from "prop-types";
 import { TransitionGroup } from "react-transition-group";
 import AlertTransition from "../alert-transition";
-
 import styles from "./styles";
 
 export const ENTER_TIMEOUT = 500;
@@ -24,5 +24,11 @@ const AlertContainer = ({ position = "top-right", children, classes }) => {
 		</div>
 	);
 };
+
+export const PropTypes = {
+	position: oneOf(["top-right", "top-left", "bottom-right", "bottom-left"])
+};
+
+AlertContainer.propTypes = PropTypes;
 
 export default styles(AlertContainer);

--- a/src/container/styles.jsx
+++ b/src/container/styles.jsx
@@ -1,7 +1,6 @@
 import { bootstrap } from "toetag";
 import useSheet from "react-jss";
-
-const MAGICAL_MAX_HEIGHT = "20em";
+import transitionStyles from "../transition-styles";
 
 export default useSheet({
 	container: {
@@ -30,28 +29,5 @@ export default useSheet({
 		bottom: 0,
 		left: 0
 	},
-	enter: {
-		opacity: 0.01,
-		transform: "translateX(-25%)",
-		maxHeight: 0,
-		overflow: "hidden",
-		transition: ".25s ease-in"
-	},
-	enterActive: {
-		opacity: 1,
-		transform: "translateX(0)",
-		maxHeight: MAGICAL_MAX_HEIGHT
-	},
-	leave: {
-		opacity: 1,
-		transform: "translateX(0)",
-		maxHeight: MAGICAL_MAX_HEIGHT,
-		overflow: "hidden",
-		transition: ".25s ease-out"
-	},
-	leaveActive: {
-		opacity: 0.01,
-		transform: "translateX(25%)",
-		maxHeight: 0
-	}
+	...transitionStyles
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 export AlertList from "./alert-list";
-
+export AlertTransition from "./alert-transition";
 export Alert from "./alert-timer";
 export AlertContainer from "./container";

--- a/src/transition-styles.js
+++ b/src/transition-styles.js
@@ -1,0 +1,28 @@
+export const MAGICAL_MAX_HEIGHT = "20em";
+
+export default {
+	enter: {
+		opacity: 0.01,
+		transform: "translateX(-25%)",
+		maxHeight: 0,
+		overflow: "hidden",
+		transition: ".25s ease-in"
+	},
+	enterActive: {
+		opacity: 1,
+		transform: "translateX(0)",
+		maxHeight: MAGICAL_MAX_HEIGHT
+	},
+	exit: {
+		opacity: 1,
+		transform: "translateX(0)",
+		maxHeight: MAGICAL_MAX_HEIGHT,
+		overflow: "hidden",
+		transition: ".25s ease-out"
+	},
+	exitActive: {
+		opacity: 0.01,
+		transform: "translateX(25%)",
+		maxHeight: 0
+	}
+};

--- a/version.js
+++ b/version.js
@@ -1,0 +1,5 @@
+const json = require("json-update");
+
+const version = process.argv[2];
+
+json.update("package.json", { version });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,12 +19,7 @@ module.exports = {
 			{
 				test: /\.jsx?$/,
 				loader: "babel-loader",
-				include: [path.resolve("./src"), path.resolve("./docs")],
-				query: isDebugBuild
-					? {
-							presets: ["react-hmre"]
-						}
-					: undefined
+				include: [path.resolve("./src"), path.resolve("./docs")]
 			},
 			{
 				test: /\.css$/,


### PR DESCRIPTION
- Update dependencies for v16 compatibility.
- Migrate from `react-addons-css-transition-group`/`CSSTransitionGroup` to `react-transition-group`/`TransitionGroup` & `CSSTransition`.