### PR TITLE
Fix broken dismissing of alerts

### DIFF
--- a/src/alert-transition.jsx
+++ b/src/alert-transition.jsx
@@ -6,15 +6,9 @@ import useSheet from "react-jss";
 
 const timeout = { enter: ENTER_TIMEOUT, exit: EXIT_TIMEOUT };
 
-const AlertTransition = ({ sheet: { classes }, ...props }) =>
-	props && props.children ? (
-		<CSSTransition
-			timeout={timeout}
-			classNames={classes}
-			onExited={props.onExited}
-		>
-			{props.children}
-		</CSSTransition>
-	) : null;
+const AlertTransition = ({ sheet: { classes }, ...props }) => {
+	delete props.classes; // if it is there (it may not be depending on which version of JSS is used)
+	return <CSSTransition timeout={timeout} classNames={classes} {...props} />;
+};
 
 export default useSheet(transitionStyles)(AlertTransition);


### PR DESCRIPTION
This fixes #41 by reverting part of #40 which fixed #39. The `CSSTransition` needs the props passed down from the `TransitionGroup`. We just want to avoid passing down extraneous props to that element to avoid warnings in React v15.

Tested with the doc app using both React v15 & v16.